### PR TITLE
fix: properly export type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gh": "node publish.js"
   },
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/qr-code-generator-lib.cjs",
     "default": "./dist/qr-code-generator-lib.mjs"
   },


### PR DESCRIPTION
Addressed https://publint.dev/qr-code-generator-lib@1.0.1 warnings